### PR TITLE
Run-depend on `joint_trajectory_controller`

### DIFF
--- a/schunk_svh_driver/package.xml
+++ b/schunk_svh_driver/package.xml
@@ -41,6 +41,7 @@
   <exec_depend>python_qt_binding</exec_depend>
   <exec_depend>qt_gui</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>


### PR DESCRIPTION
We need this thing for joint actuation in the examples.