### PR TITLE
Add missing execution dependencies

### DIFF
--- a/schunk_svh_driver/package.xml
+++ b/schunk_svh_driver/package.xml
@@ -15,7 +15,15 @@ schematypens="http://www.w3.org/2001/XMLSchema"?>
         <depend>pluginlib</depend>
         <depend>rclcpp</depend>
         <depend>schunk_svh_library</depend>
+
         <exec_depend>schunk_svh_description</exec_depend>
+        <exec_depend>controller_manager</exec_depend>
+        <exec_depend>joint_state_controller</exec_depend>
+        <exec_depend>joint_trajectory_controller</exec_depend>
+        <exec_depend>launch</exec_depend>
+        <exec_depend>launch_ros</exec_depend>
+        <exec_depend>ros2launch</exec_depend>
+        <exec_depend>xacro</exec_depend>
 
         <test_depend>ament_lint_auto</test_depend>
         <!--<test_depend>ament_lint_common</test_depend>-->


### PR DESCRIPTION
We need those for our current, minimal setup.

Possibly fixes #10 