### PR TITLE
Add pipeline for integration testing

### DIFF
--- a/schunk_svh_tests/CMakeLists.txt
+++ b/schunk_svh_tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(schunk_svh_tests)
+
+find_package(ament_cmake REQUIRED)
+
+
+if(BUILD_TESTING)
+  find_package(schunk_svh_driver REQUIRED)
+  find_package(controller_manager_msgs REQUIRED)
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(integration_tests/test_startup.py)
+endif()
+
+ament_package()

--- a/schunk_svh_tests/README.md
+++ b/schunk_svh_tests/README.md
@@ -1,0 +1,13 @@
+# Schunk SVH Tests
+Integration tests and high-level concept validation for the Schunk SVH ROS2 driver.
+
+Useful information on integration tests in ROS2 is available [here][1]
+
+## Run tests manually
+In a sourced terminal, call
+```bash
+colcon test --packages-select schunk_svh_tests && colcon test-result --verbose
+```
+to run and inspect the integration tests locally.
+
+[1]: https://github.com/ros2/launch/tree/master/launch_testing#quick-start-example

--- a/schunk_svh_tests/integration_tests/test_startup.py
+++ b/schunk_svh_tests/integration_tests/test_startup.py
@@ -29,10 +29,9 @@ def generate_test_description():
 
 
 class IntegrationTest(unittest.TestCase):
-    """ An integration test for controller initialization and startup
+    """ An integration test for the basic workflow of ROS2-control
 
-    We check if each controller successfully performs the life cycle of:
-    `initialized` - `active` - `update` - `inactive`.
+    We test if the hand controller and the joint state controller started as expected.
     """
     def __init__(self, *args):
         super().__init__(*args)
@@ -44,7 +43,6 @@ class IntegrationTest(unittest.TestCase):
         cls.setup_interfaces(cls)
 
         cls.our_controllers = [
-            'left_hand',
             'right_hand',
             'joint_state_controller',
         ]
@@ -67,15 +65,15 @@ class IntegrationTest(unittest.TestCase):
         if not self.switch_controller.wait_for_service(timeout.nanoseconds/1e9):
             self.fail("Service switch_controllers not available")
 
-    def test_controller_initialization(self):
-        """ Test whether every controller got initialized correctly
+    def test_controller_startup(self):
+        """ Test whether every controller started correctly
 
         We check if the list of all controllers currently managed by the
         controller manager contains our controllers and if they have `state:
-        inactive`.
+        active`.
         """
         for name in self.our_controllers:
-            self.assertTrue(self.check_state(name, 'inactive'), f"{name} is initialized correctly")
+            self.assertTrue(self.check_state(name, 'active'), f"{name} is started correctly")
 
     def check_state(self, controller, state):
         """ Check the controller's state

--- a/schunk_svh_tests/integration_tests/test_startup.py
+++ b/schunk_svh_tests/integration_tests/test_startup.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import unittest
+
+import launch
+import launch.actions
+import launch_testing.actions
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+import os
+import time
+import rclpy
+from rclpy.node import Node
+from controller_manager_msgs.srv import ListControllers
+from controller_manager_msgs.srv import SwitchController
+
+
+def generate_test_description():
+
+    setup = IncludeLaunchDescription(
+        PathJoinSubstitution(
+            [FindPackageShare("schunk_svh_driver"), "launch", "schunk_svh_driver.launch.py"]
+        )
+    )
+    until_ready = 10.0 # sec
+    return LaunchDescription([setup, TimerAction(period=until_ready, actions=[launch_testing.actions.ReadyToTest()])])
+
+
+class IntegrationTest(unittest.TestCase):
+    """ An integration test for controller initialization and startup
+
+    We check if each controller successfully performs the life cycle of:
+    `initialized` - `active` - `update` - `inactive`.
+    """
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("test_startup")
+        cls.setup_interfaces(cls)
+
+        cls.our_controllers = [
+            'left_hand',
+            'right_hand',
+            'joint_state_controller',
+        ]
+
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def setup_interfaces(self):
+        """ Setup interfaces for ROS2 services and topics """
+
+        timeout = rclpy.time.Duration(seconds=5)
+        self.list_controllers = self.node.create_client(ListControllers, "/controller_manager/list_controllers")
+        if not self.list_controllers.wait_for_service(timeout.nanoseconds/1e9):
+            self.fail("Service list_controllers not available")
+
+        self.switch_controller = self.node.create_client(SwitchController, '/controller_manager/switch_controller')
+        if not self.switch_controller.wait_for_service(timeout.nanoseconds/1e9):
+            self.fail("Service switch_controllers not available")
+
+    def test_controller_initialization(self):
+        """ Test whether every controller got initialized correctly
+
+        We check if the list of all controllers currently managed by the
+        controller manager contains our controllers and if they have `state:
+        inactive`.
+        """
+        for name in self.our_controllers:
+            self.assertTrue(self.check_state(name, 'inactive'), f"{name} is initialized correctly")
+
+    def check_state(self, controller, state):
+        """ Check the controller's state
+
+        Return True if the controller's state is `state`, else False.
+        Return False if the controller is not listed.
+        """
+        req = ListControllers.Request()
+        future = self.list_controllers.call_async(req)
+        rclpy.spin_until_future_complete(self.node, future)
+        for entry in future.result().controller:
+            if entry.name == controller:
+                return True if entry.state == state else False
+        return False

--- a/schunk_svh_tests/package.xml
+++ b/schunk_svh_tests/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>schunk_svh_tests</name>
+  <version>0.0.0</version>
+  <description>Integration tests for the Schunk SVH ROS2 driver</description>
+  <maintainer email="scherzin@fzi.de">Stefan Scherzinger</maintainer>
+  <license>GPL-3.0-or-later</license>
+
+  <test_depend>controller_manager_msgs</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>schunk_svh_driver</test_depend>
+
+
+</package>


### PR DESCRIPTION
## Goal
Provide a minimal test setup for starting the Schunk SVH driver with ROS2-control.
This checks our current installation process on a fresh OS install.

## Steps
- [x] Add boilerplate setup for integration testing
- [x] Find a suitable mechanism to check if all dependencies are available on startup.

---
Fixes #10