### PR TITLE
Fix links in changelogs

### DIFF
--- a/schunk_svh/CHANGELOG.rst
+++ b/schunk_svh/CHANGELOG.rst
@@ -8,8 +8,7 @@ Forthcoming
   Switch license to the GPLv3
   See merge request ros/schunk_svh_driver!23
 * Update SPDX license indicator in package.xml
-  This is according to
-  [here](https://www.gnu.org/licenses/identify-licenses-clearly.html)
+  This is according to `here <https://www.gnu.org/licenses/identify-licenses-clearly.html>`_.
 * Add `schunk_svh_msgs` to meta package.xml
 * Merge branch 'meta-package' into 'update-and-upgrade'
   Meta package

--- a/schunk_svh_description/CHANGELOG.rst
+++ b/schunk_svh_description/CHANGELOG.rst
@@ -8,7 +8,7 @@ Forthcoming
   Add an example setup for Gazebo
 * Update the plugin to mimic joints
   The new plugin is now maintained
-  [here](https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins).
+  `here <https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins>`_.
   Also add suitable `PID` gains for the mimicked joints.
 * Add a minimal Gazebo example
 * Update maintainer info
@@ -25,7 +25,7 @@ Forthcoming
   CMake 3.10 is Bionic's (Ubuntu 18.04) shipping version.
 * Update SPDX license indicator in package.xml
   This is according to
-  [here](https://www.gnu.org/licenses/identify-licenses-clearly.html)
+  `here <https://www.gnu.org/licenses/identify-licenses-clearly.html>`_.
 * Support left and right hands through launch parameters
   We now load the correct ROS-control configuration depending on whether
   users start a `right_hand` or a `left_hand`.

--- a/schunk_svh_driver/CHANGELOG.rst
+++ b/schunk_svh_driver/CHANGELOG.rst
@@ -6,7 +6,7 @@ Forthcoming
 -----------
 * Update the plugin to mimic joints
   The new plugin is now maintained
-  [here](https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins).
+  `here <https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins>`_.
   Also add suitable `PID` gains for the mimicked joints.
 * Add `PID` gains for Gazebo
   We now have stable joint position control.
@@ -31,12 +31,12 @@ Forthcoming
 * Apply clang-format through pre-commit hook
 * Add license notice to all development files
   The text is in accordance with the recommendations from
-  [here](https://www.gnu.org/licenses/gpl-howto.html)
+  `here <https://www.gnu.org/licenses/gpl-howto.html>`_
   in the section *The license notices*.
 * Remove old license texts
 * Update SPDX license indicator in package.xml
   This is according to
-  [here](https://www.gnu.org/licenses/identify-licenses-clearly.html)
+  `here <https://www.gnu.org/licenses/identify-licenses-clearly.html>`_.
 * Support left and right hands through launch parameters
   We now load the correct ROS-control configuration depending on whether
   users start a `right_hand` or a `left_hand`.

--- a/schunk_svh_msgs/CHANGELOG.rst
+++ b/schunk_svh_msgs/CHANGELOG.rst
@@ -9,7 +9,7 @@ Forthcoming
   See merge request ros/schunk_svh_driver!23
 * Update SPDX license indicator in package.xml
   This is according to
-  [here](https://www.gnu.org/licenses/identify-licenses-clearly.html)
+  `here <https://www.gnu.org/licenses/identify-licenses-clearly.html>`_.
 * Update top-level readme
   Also add lightweight readmes for each sub package.
 * Merge branch 'meta-package' into 'update-and-upgrade'


### PR DESCRIPTION
The `.rst` format differs here w.r.t. the markdown format.