### PR TITLE
Correctly depend on `schunk_svh_description`

### DIFF
--- a/schunk_svh_simulation/CMakeLists.txt
+++ b/schunk_svh_simulation/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 project(schunk_svh_simulation)
 
 find_package(catkin REQUIRED COMPONENTS
-    schunk_svh_description
 )
 
 catkin_package(


### PR DESCRIPTION
## Goal
Fix the current [ros build farm](https://build.ros.org/job/Mbin_ubhf_uBhf__schunk_svh_simulation__ubuntu_bionic_armhf__binary/5/console). It seems that `schunk_svh_description` is not found.